### PR TITLE
Modify ADBMobile plugin to call lifecycle methods

### DIFF
--- a/platforms/android/src/com/adobe/ADBMobile_PhoneGap.java
+++ b/platforms/android/src/com/adobe/ADBMobile_PhoneGap.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import android.widget.Switch;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CallbackContext;
 
 import org.json.JSONArray;
@@ -586,5 +587,26 @@ public class ADBMobile_PhoneGap extends CordovaPlugin {
         HashMap<String, Object> table = new HashMap<String, Object>();
         table.putAll(map);
         return table;
+    }
+
+    // =====================
+    // Plugin life cycle events
+    // =====================
+    @Override
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        com.adobe.mobile.Config.setContext(this.cordova.getActivity().getApplicationContext());
+    }
+    
+    @Override
+    public void onPause(boolean multitasking) {
+        super.onPause(multitasking);
+        com.adobe.mobile.Config.pauseCollectingLifecycleData();
+    }
+
+    @Override
+    public void onResume(boolean multitasking) {
+        super.onResume(multitasking);
+        com.adobe.mobile.Config.collectLifecycleData();
     }
 }

--- a/platforms/android/src/com/adobe/phonegap/app/PhoneGap.java
+++ b/platforms/android/src/com/adobe/phonegap/app/PhoneGap.java
@@ -32,19 +32,6 @@ public class PhoneGap extends CordovaActivity
         // Set by <content src="index.html" /> in config.xml
         super.loadUrl(Config.getStartUrl());
         //super.loadUrl("file:///android_asset/www/index.html")
-        com.adobe.mobile.Config.setContext(this.getApplicationContext());
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        com.adobe.mobile.Config.collectLifecycleData();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        com.adobe.mobile.Config.pauseCollectingLifecycleData();
     }
 }
 

--- a/plugins/ADBMobile/sdks/Cordova/ADBMobile/Android/ADBMobile_PhoneGap.java
+++ b/plugins/ADBMobile/sdks/Cordova/ADBMobile/Android/ADBMobile_PhoneGap.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import android.widget.Switch;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CallbackContext;
 
 import org.json.JSONArray;
@@ -586,5 +587,26 @@ public class ADBMobile_PhoneGap extends CordovaPlugin {
         HashMap<String, Object> table = new HashMap<String, Object>();
         table.putAll(map);
         return table;
+    }
+
+    // =====================
+    // Plugin life cycle events
+    // =====================
+    @Override
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        com.adobe.mobile.Config.setContext(this.cordova.getActivity().getApplicationContext());
+    }
+    
+    @Override
+    public void onPause(boolean multitasking) {
+        super.onPause(multitasking);
+        com.adobe.mobile.Config.pauseCollectingLifecycleData();
+    }
+
+    @Override
+    public void onResume(boolean multitasking) {
+        super.onResume(multitasking);
+        com.adobe.mobile.Config.collectLifecycleData();
     }
 }


### PR DESCRIPTION
So instead of having the main activity do the setup for the ADB Mobile plugin I've moved that code to the plugin itself. I've done testing on Android and it "appears" to work correctly but I'd love another set of eyes on this before it gets merged.