### PR TITLE
Upgrade dev app to use Push Plugin v2

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -16,51 +16,6 @@
     <preference name="DisallowOverscroll" value="true" />
     <access origin="*" />
     <content src="index.html" />
-    <plugin name="cordova-plugin-battery-status" spec="~1.2.4" />
-    <plugin name="cordova-plugin-camera" spec="~2.4.1">
-        <variable name="CAMERA_USAGE_DESCRIPTION" value="Camera used for development purposes" />
-    </plugin>
-    <plugin name="cordova-plugin-console" spec="~1.0.7" />
-    <plugin name="cordova-plugin-contacts" spec="~2.3.1">
-        <variable name="CONTACTS_USAGE_DESCRIPTION" value="Contacts used for development purposes" />
-    </plugin>
-    <plugin name="cordova-plugin-device" spec="~1.1.6" />
-    <plugin name="cordova-plugin-device-motion" spec="~1.2.5" />
-    <plugin name="cordova-plugin-device-orientation" spec="~1.0.7" />
-    <plugin name="cordova-plugin-dialogs" spec="~1.3.3" />
-    <plugin name="cordova-plugin-file" spec="~4.3.3" />
-    <plugin name="cordova-plugin-file-transfer" spec="~1.6.3" />
-    <plugin name="cordova-plugin-geolocation" spec="~2.4.3">
-        <variable name="GEOLOCATION_USAGE_DESCRIPTION" value="Geolocation used for development purposes" />
-    </plugin>
-    <plugin name="cordova-plugin-globalization" spec="~1.0.7" />
-    <plugin name="cordova-plugin-inappbrowser" spec="~1.7.1" />
-    <plugin name="cordova-plugin-media" spec="~3.0.1" />
-    <plugin name="cordova-plugin-media-capture" spec="~1.4.3">
-        <variable name="CAMERA_USAGE_DESCRIPTION" value="Camera used for development purposes" />
-        <variable name="MICROPHONE_USAGE_DESCRIPTION" value="Microphone used for development purposes" />
-        <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Photo library used for development purposes" />
-    </plugin>
-    <plugin name="cordova-plugin-network-information" spec="~1.3.3" />
-    <plugin name="cordova-plugin-splashscreen" spec="~4.0.3" />
-    <plugin name="cordova-plugin-statusbar" spec="~2.2.3" />
-    <plugin name="cordova-plugin-vibration" spec="~2.1.5" />
-    <plugin name="phonegap-plugin-contentsync" spec="~1.3.6" />
-    <plugin name="cordova-plugin-whitelist" spec="~1.3.0" />
-    <plugin name="cordova-plugin-insomnia" spec="~4.3.0" />
-    <plugin name="cordova-plugin-ble-central" spec="~1.1.4">
-        <variable name="BLUETOOTH_USAGE_DESCRIPTION" value="Bluetooth development purposes" />
-    </plugin>
-    <plugin name="phonegap-plugin-push" spec="~1.10.2">
-        <variable name="SENDER_ID" value="85075801930" />
-    </plugin>
-    <plugin name="cordova-plugin-x-socialsharing" spec="https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin" />
-    <plugin name="phonegap-plugin-barcodescanner" spec="~6.0.6">
-        <variable name="CAMERA_USAGE_DESCRIPTION" value="Camera used for development purposes" />
-    </plugin>
-    <plugin name="phonegap-plugin-mobile-accessibility" spec="~1.0.4" />
-    <plugin name="com.wikitude.phonegap.WikitudePlugin" spec="https://github.com/timkim/wikitude-cordova-plugin.git#devApp" />
-    <plugin name="cordova-plugin-screen-orientation" spec="~2.0.0" />
     <platform name="ios">
         <preference name="Orientation" value="all" />
         <preference name="AutoHideSplashScreen" value="false" />
@@ -101,6 +56,7 @@
         <icon density="mdpi" src="resources/icon/android/icon-48.png" />
         <icon density="hdpi" src="resources/icon/android/icon-72.png" />
         <icon density="xhdpi" src="resources/icon/android/icon-96.png" />
+        <resource-file src="google-services.json" target="google-services.json" />
     </platform>
     <platform name="wp8">
         <preference name="AutoHideSplashScreen" value="false" />
@@ -109,7 +65,50 @@
         <icon height="159" src="resources/icon/wp8/TileMedium.png" width="159" />
         <icon height="110" src="resources/icon/wp8/TileSmall.png" width="110" />
     </platform>
-    <engine name="wp8" spec="~3.8.2" />
-    <engine name="android" spec="~6.2.3" />
+    <engine name="android" spec="^6.2.3" />
     <engine name="ios" spec="~4.4.0" />
+    <engine name="wp8" spec="~3.8.2" />
+    <plugin name="com.wikitude.phonegap.WikitudePlugin" spec="https://github.com/timkim/wikitude-cordova-plugin.git#devApp" />
+    <plugin name="cordova-plugin-battery-status" spec="^1.2.4" />
+    <plugin name="cordova-plugin-ble-central" spec="^1.1.4">
+        <variable name="BLUETOOTH_USAGE_DESCRIPTION" value="Bluetooth development purposes" />
+    </plugin>
+    <plugin name="cordova-plugin-camera" spec="^2.4.1">
+        <variable name="CAMERA_USAGE_DESCRIPTION" value="Camera used for development purposes" />
+    </plugin>
+    <plugin name="cordova-plugin-console" spec="^1.0.7" />
+    <plugin name="cordova-plugin-contacts" spec="^2.3.1">
+        <variable name="CONTACTS_USAGE_DESCRIPTION" value="Contacts used for development purposes" />
+    </plugin>
+    <plugin name="cordova-plugin-device" spec="^1.1.6" />
+    <plugin name="cordova-plugin-device-motion" spec="^1.2.5" />
+    <plugin name="cordova-plugin-device-orientation" spec="^1.0.7" />
+    <plugin name="cordova-plugin-dialogs" spec="^1.3.3" />
+    <plugin name="cordova-plugin-file" spec="^4.3.3" />
+    <plugin name="cordova-plugin-file-transfer" spec="^1.6.3" />
+    <plugin name="cordova-plugin-geolocation" spec="^2.4.3">
+        <variable name="GEOLOCATION_USAGE_DESCRIPTION" value="Geolocation used for development purposes" />
+    </plugin>
+    <plugin name="cordova-plugin-globalization" spec="^1.0.7" />
+    <plugin name="cordova-plugin-inappbrowser" spec="^1.7.1" />
+    <plugin name="cordova-plugin-insomnia" spec="^4.3.0" />
+    <plugin name="cordova-plugin-media" spec="^3.0.1" />
+    <plugin name="cordova-plugin-media-capture" spec="^1.4.3">
+        <variable name="CAMERA_USAGE_DESCRIPTION" value="Camera used for development purposes" />
+        <variable name="MICROPHONE_USAGE_DESCRIPTION" value="Microphone used for development purposes" />
+        <variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="Photo library used for development purposes" />
+    </plugin>
+    <plugin name="cordova-plugin-network-information" spec="^1.3.3" />
+    <plugin name="cordova-plugin-screen-orientation" spec="^2.0.1" />
+    <plugin name="cordova-plugin-splashscreen" spec="^4.0.3" />
+    <plugin name="cordova-plugin-statusbar" spec="^2.2.3" />
+    <plugin name="cordova-plugin-vibration" spec="^2.1.5" />
+    <plugin name="cordova-plugin-whitelist" spec="^1.3.2" />
+    <plugin name="cordova-plugin-x-socialsharing" spec="git+https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin.git" />
+    <plugin name="phonegap-plugin-barcodescanner" spec="^6.0.8">
+        <variable name="CAMERA_USAGE_DESCRIPTION" value="Camera used for development purposes" />
+    </plugin>
+    <plugin name="phonegap-plugin-contentsync" spec="^1.3.6" />
+    <plugin name="phonegap-plugin-mobile-accessibility" spec="^1.0.5" />
+    <plugin name="phonegap-plugin-push" spec="^2.0.0" />
 </widget>

--- a/google-services.json
+++ b/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "996231231186",
+    "firebase_url": "https://fcm-pushapi-phonegap-com.firebaseio.com",
+    "project_id": "fcm-pushapi-phonegap-com",
+    "storage_bucket": "fcm-pushapi-phonegap-com.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:996231231186:android:845d258a77ddcab7",
+        "android_client_info": {
+          "package_name": "com.adobe.phonegap.app"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "996231231186-jr95lvbr36h47lh74olqcb8935it35c2.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAwC51I96VcZT_ss6e3iSVMSSyvemVYYa4"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "jasmine-node": "1.14.5",
         "less": "2.7.1",
         "npm-run": "4.1.0",
-        "phonegap": "6.5.0",
+        "phonegap": "7.0.0",
         "request": "2.65.0",
         "xml2js": "0.4.12"
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "release-phonegap-wp8": "bash ./resources/script/phonegap-wp8.sh",
         "build:less": "lessc -x resources/less/app.less > www/css/app.css",
         "build:clean": "node ./resources/script/clean.js",
-        "build:config-wp8" : "node ./resources/script/config-wp8.js",
+        "build:config-wp8": "node ./resources/script/config-wp8.js",
         "build:config:restore": "node ./resources/script/restore-config.js",
         "build:setup": "npm run build:clean && npm run build:setup:directories",
         "build:setup:adhoc": "npm run build:setup && node ./resources/script/setup-ad-hoc.js",
@@ -27,8 +27,7 @@
         "test": "jasmine-node tests/browser",
         "test-wp8": "npm run build:setup && phonegap --verbose build wp8 --test"
     },
-    "dependencies": {
-    },
+    "dependencies": {},
     "devDependencies": {
         "app-root-path": "1.0.0",
         "fs-extra": "0.24.0",


### PR DESCRIPTION
Hey @timkim can you take a look at this PR. I've been able to update the pinned version of cordova to 7.0.0 and push plugin to 2.0.0. When I build I can successfully receive a push message on Android (iOS is unchanged but should still be tested). 

However, I'm noticing some really odd things:

- The %PHONEGAP_APP_VERSION% doesn't seem to get updated in the built apk which is weird since the platforms/android/assets/www/index.html is up to date
- The build updates the package.json file and it adds a bunch of dependencies including the platform and plugins. That's not bad but it also seems to add anything on the engine tag which is not an actually npm package. May need to talk to @stevengill.
- The build itself takes over 5 minutes to complete which is frankly a bit nutz.