### PR TITLE
Replace requireCordovaModule with require for Cordova 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "phonegap-plugin-barcodescanner": "^6.0.8",
     "phonegap-plugin-contentsync": "^1.4.1",
     "phonegap-plugin-mobile-accessibility": "^1.0.5",
-    "phonegap-plugin-push": "^2.1.2"
+    "phonegap-plugin-push": "^2.1.2",
+    "q": "^1.5.1"
   },
   "devDependencies": {
     "app-root-path": "1.0.0",

--- a/resources/script/add-hockeyapp.js
+++ b/resources/script/add-hockeyapp.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 module.exports = function(ctx) {
-    var fs = ctx.requireCordovaModule('fs'),
-      path = ctx.requireCordovaModule('path'),
-      deferral = ctx.requireCordovaModule('q').defer();
+    var fs = require('fs'),
+      path = require('path'),
+      deferral = require('q').defer();
 
     console.log('Running: Applying HockeyApp App ID for current platform');
 

--- a/resources/script/add-version.js
+++ b/resources/script/add-version.js
@@ -3,9 +3,9 @@
 module.exports = function(ctx) {
   console.log('Running: Adding version and build info to index.html');
 
-  var fs = ctx.requireCordovaModule('fs'),
-      path = ctx.requireCordovaModule('path'),
-      deferral = ctx.requireCordovaModule('q').defer(),
+  var fs = require('fs'),
+      path = require('path'),
+      deferral = require('q').defer(),
       ConfigParser = ctx.requireCordovaModule('cordova-common').ConfigParser;
 
   var configPath = path.join(ctx.opts.projectRoot, 'config.xml');

--- a/resources/script/copy-android-push-icon.js
+++ b/resources/script/copy-android-push-icon.js
@@ -9,9 +9,9 @@ module.exports = function(ctx) {
         return;
     }
 
-    var fs = ctx.requireCordovaModule('fs'),
-        path = ctx.requireCordovaModule('path'),
-        deferral = ctx.requireCordovaModule('q').defer();
+    var fs = require('fs'),
+        path = require('path'),
+        deferral = require('q').defer();
 
     var destPath = path.join(ctx.opts.projectRoot, 'platforms/android/res/drawable-hdpi/pushicon.png');
     var splashPath = path.join(ctx.opts.projectRoot, 'resources/icon/android/pushicon.png');

--- a/resources/script/remove-hockeyapp.js
+++ b/resources/script/remove-hockeyapp.js
@@ -4,9 +4,9 @@ module.exports = function(ctx) {
 
     console.log('Running: Removing HockeyApp from app.js');
 
-    var fs = ctx.requireCordovaModule('fs'),
-        path = ctx.requireCordovaModule('path'),
-        deferral = ctx.requireCordovaModule('q').defer();
+    var fs = require('fs'),
+        path = require('path'),
+        deferral = require('q').defer();
 
     // modify app.js according to current platform
     var appDest = path.join(ctx.opts.projectRoot, 'www/js/app.js');

--- a/resources/script/remove-version.js
+++ b/resources/script/remove-version.js
@@ -3,9 +3,9 @@
 module.exports = function(ctx) {
   console.log('Running: Removing version and build info from index.html');
 
-  var fs = ctx.requireCordovaModule('fs'),
-      path = ctx.requireCordovaModule('path'),
-      deferral = ctx.requireCordovaModule('q').defer();
+  var fs = require('fs'),
+      path = require('path'),
+      deferral = require('q').defer();
 
   var indexPath = path.join(ctx.opts.projectRoot, 'www/index.html');
   var versionText = '<!-- %PHONEGAP_APP_VERSION_START% -->' + '<!-- %PHONEGAP_APP_VERSION_END% -->';


### PR DESCRIPTION
## Background

Cordova-Lib 9.x used in Cordova 9 has deprecated using `requireCordovaModule` to require for non-Cordova modules. 

https://github.com/apache/cordova-lib/pull/707

## Changes

- Added `q@^1.5.1` as a dependency.
- Replaced `requireCordovaModule` usage with `require`.

## Test steps

- `npm t`
- `npm run lint`
- `npm run phonegap`

**More testing may be required.**

## Other found issues outside of the changes scope

`adhoc-android` and `adhoc-ios` fails but not related to this change.
```
Error: Failed to fetch plugin cordova-plugin-hockeyapp@5.1.2 via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
...
npm ERR! peerinvalid The package eslint-config-standard@12.0.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-semistandard@12.0.1 wants eslint-config-standard@^11.0.0
```